### PR TITLE
[add] cloud-shell profile switcher: cshell added.

### DIFF
--- a/cshell
+++ b/cshell
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+### CUSTOMIZE SECTION ###
+#####
+##### put your default cloud-shell configuration name here.
+#####
+MY_PRIVATE_CONFIG_NAME=tokyo
+
+### static code ###
+##### 1. save current config-name to VAR
+##### 2. execute cloud-shell ssh by default config-name
+##### 3. restore config-name from VAR
+ACTIVE_CONFIG=$(cat ~/.config/gcloud/active_config)
+gcctx is $MY_PRIVATE_CONFIG_NAME && \
+  gcloud alpha cloud-shell ssh ; \
+  gcctx is $ACTIVE_CONFIG
+
+### EOF ###


### PR DESCRIPTION
## what is `cshell`
* `Google Cloud Shell` wrapper for gcctx. (with gcctx)

## syntax
* cshell

## how to install
1. clone it
1. change the VAR `MY_PRIVATE_CONFIG_NAME=`
1. execute `cshell`